### PR TITLE
fix problem in player.findYakuman()

### DIFF
--- a/src/main/java/org/mahjong4j/Player.java
+++ b/src/main/java/org/mahjong4j/Player.java
@@ -105,11 +105,13 @@ public class Player {
      * @return 役満が見つかったか
      */
     private boolean findYakuman() {
-        //役満をストックしておき、見つかったら先にこちらに保存する
-        List<Yakuman> yakumanStock = new ArrayList<>(4);
+        
 
         //それぞれの面子の完成形で判定する
         for (MentsuComp comp : hands.getMentsuCompSet()) {
+        	//役満をストックしておき、見つかったら先にこちらに保存する
+            List<Yakuman> yakumanStock = new ArrayList<>(4);
+        	
             Set<YakumanResolver> yakumanResolverSet
                 = Mahjong4jYakuConfig.getYakumanResolverSet(comp, generalSituation, personalSituation);
 

--- a/src/test/java/org/mahjong4j/withsituation/TenhoTest.java
+++ b/src/test/java/org/mahjong4j/withsituation/TenhoTest.java
@@ -25,6 +25,8 @@ import static org.mahjong4j.yaku.yakuman.Yakuman.TENHO;
  */
 public class TenhoTest {
     private Player player;
+    private Player playerMultiMentsuComp;
+    
 
     @Before
     public void setUp() throws Exception {
@@ -35,7 +37,7 @@ public class TenhoTest {
             0, 0, 0, 0,
             0, 0, 0
         };
-        Tile last = M6;
+        Tile last = M1;
         Hands hands = new Hands(tiles, last);
         List<Tile> dora = new ArrayList<>(1);
         dora.add(CHN);
@@ -49,36 +51,68 @@ public class TenhoTest {
 
         player = new Player(hands, generalSituation, personalSituation);
         player.calculate();
+        
+        // two MentsuComp：七対子、二盃口 
+        int[] tiles2 = {
+	        2, 2, 2, 0, 0, 0, 0, 0, 0,
+	        2, 2, 2, 0, 0, 0, 0, 0, 0,
+	        0, 0, 2, 0, 0, 0, 0, 0, 0,
+	        0, 0, 0, 0,
+	        0, 0, 0
+	    };
+	    Tile last2 = M1;
+	    Hands hands2 = new Hands(tiles2, last2);
+	    List<Tile> dora2 = new ArrayList<>(1);
+	    dora.add(CHN);
+	
+	    List<Tile> uradora2 = new ArrayList<>(1);
+	    uradora.add(M2);
+	    GeneralSituation generalSituation2;
+	    generalSituation2 = new GeneralSituation(true, false, TON, dora2, uradora2);
+	    PersonalSituation personalSituation2;
+	    personalSituation2 = new PersonalSituation(true, true, false, false, false, false, TON);
+	
+	    playerMultiMentsuComp = new Player(hands2, generalSituation2, personalSituation2);
+	    playerMultiMentsuComp.calculate();
     }
 
     @Test
     public void testGetYakumanListSize() throws Exception {
         List<Yakuman> actual = player.getYakumanList();
-
+        assertEquals(1, actual.size());
+        
+        actual = playerMultiMentsuComp.getYakumanList();
         assertEquals(1, actual.size());
     }
 
     @Test
     public void testGetYakumanListItem() throws Exception {
         List<Yakuman> actual = player.getYakumanList();
-
+        assertThat(actual, hasItems(TENHO));
+        
+        actual = playerMultiMentsuComp.getYakumanList();
         assertThat(actual, hasItems(TENHO));
     }
 
     @Test
     public void testGetNormalYakuListSize() throws Exception {
         List<NormalYaku> actual = player.getNormalYakuList();
-
+        assertEquals(0, actual.size());
+        
+        actual = playerMultiMentsuComp.getNormalYakuList();
         assertEquals(0, actual.size());
     }
 
     @Test
     public void testGetFu() throws Exception {
         assertEquals(0, player.getFu());
+        
+        assertEquals(0, playerMultiMentsuComp.getFu());
     }
 
     @Test
     public void testGetScore() throws Exception {
         assertEquals(SCORE48000, player.getScore());
+        assertEquals(SCORE48000, playerMultiMentsuComp.getScore());
     }
 }


### PR DESCRIPTION
The new TenhoTest shows the problem : in findYakuman(), when the hands.getMentsuCompSet() > 1, each mentsuComp add to yakumanStock, but yakumanStock doesn't cleared in the next iteration. As the result, the final yakumanList.size > 1.
Fix: clear/recreate the yakumanStock in each iteration. just like in findNormalYaku().