### PR TITLE
fix Hands constuctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .project
 .classpath
 .settings
+/bin

--- a/src/main/java/org/mahjong4j/hands/Hands.java
+++ b/src/main/java/org/mahjong4j/hands/Hands.java
@@ -85,7 +85,7 @@ public class Hands {
         //整合性をチェック
         checkTiles(allTiles);
 
-        handsComp = allTiles;
+        System.arraycopy(allTiles, 0, handsComp, 0, allTiles.length);
 
         findMentsu();
     }


### PR DESCRIPTION
The shallow copy makes handsComp and inputtedTiles point to the same array instance.