### PR TITLE
fix Kokushimuso doesn't set score

### DIFF
--- a/src/main/java/org/mahjong4j/Player.java
+++ b/src/main/java/org/mahjong4j/Player.java
@@ -82,11 +82,7 @@ public class Player {
         //和了れない場合は即座に終了
         if (!hands.getCanWin()) return;
 
-        //国士無双の場合はそれ以外ありえないので保存して即座に終了
-        if (hands.getIsKokushimuso()) {
-            yakumanList.add(KOKUSHIMUSO);
-            return;
-        }
+        
 
         //役満を探し見つかれば通常役は調べずに終了
         if (findYakuman()) {
@@ -105,6 +101,12 @@ public class Player {
      * @return 役満が見つかったか
      */
     private boolean findYakuman() {
+        
+        //国士無双の場合はそれ以外ありえないので保存して即座に終了
+        if (hands.getIsKokushimuso()) {
+            yakumanList.add(KOKUSHIMUSO);
+            return true;
+        }
 
 
         //それぞれの面子の完成形で判定する

--- a/src/test/java/org/mahjong4j/player/PlayerKokushimusoTest.java
+++ b/src/test/java/org/mahjong4j/player/PlayerKokushimusoTest.java
@@ -1,0 +1,44 @@
+package org.mahjong4j.player;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mahjong4j.tile.Tile.CHN;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mahjong4j.GeneralSituation;
+import org.mahjong4j.PersonalSituation;
+import org.mahjong4j.Player;
+import org.mahjong4j.hands.Hands;
+
+/**
+ * @author hundun
+ * Created on 2019/12/30
+ */
+public class PlayerKokushimusoTest {
+    
+    private Player actual;
+
+    @Before
+    public void setUp() throws Exception {
+        int[] tiles = {
+            1, 0, 0, 0, 0, 0, 0, 0, 1,
+            1, 0, 0, 0, 0, 0, 0, 0, 1,
+            1, 0, 0, 0, 0, 0, 0, 0, 1,
+            1, 2, 1, 1,
+            1, 1, 1,
+        };
+
+        Hands hands = new Hands(tiles, CHN);
+        PersonalSituation personalSituation = new PersonalSituation();
+        GeneralSituation generalSituation = new GeneralSituation();
+        actual = new Player(hands, generalSituation, personalSituation);
+        actual.calculate();
+    }
+    
+    @Test
+    public void testRonScore() throws Exception {
+        assertTrue(actual.getScore().getRon() > 0);
+    }
+
+}


### PR DESCRIPTION
When hands is Kokushimuso,  calculate() return but doesn't set score. The new Test will fail.
In addition, check Kokushimuso should be part of findYukuman(). So move these code into findYukuman() can fix it. 